### PR TITLE
About warnings and potential issues with the "AA_EnableHighDpiScaling" attribute usage...

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -27,12 +27,12 @@
 
 int main(int argc, char *argv[])
 {
-    QApplication a(argc, argv);
     //a.setOverrideCursor(QCursor(Qt::BlankCursor));
     QApplication::setWindowIcon( QIcon(":/images/pardus-pen.svg") );
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QString name = SINGLE_INSTANCE;
 
+    QApplication a(argc, argv);
     SingleInstance cInstance;
     if(cInstance.hasPrevious(name, QCoreApplication::arguments()))
     {

--- a/main.cpp
+++ b/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
 {
     //a.setOverrideCursor(QCursor(Qt::BlankCursor));
     QApplication::setWindowIcon( QIcon(":/images/pardus-pen.svg") );
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
     QString name = SINGLE_INSTANCE;
 
     QApplication a(argc, argv);


### PR DESCRIPTION
### Issue definition and my solution suggestion
Define the "AA_EnableHighDpiScaling" attribute just before the QApplication is created. With this commit, it is aimed to fix the QApplication sequence. Terminal warning and possible dependent scaling errors that occur when starting the application are prevented.

### How to reach this issue?
Call and run _pardus-pen_ app over _Pardus 21.4 XFCE_ via _terminal_.

### Before: 
`user@pardus:~$ pardus-pen`
**`Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created.`**
`Checking for previous instance...`
`"QLocalSocket::connectToServer: Invalid name"`
`creating single instance`

### After applying my suggested commit:
`user@pardus:~/pardus-pen$ ./pardus-pen`
`Checking for previous instance...`
`"QLocalSocket::connectToServer: Invalid name"`
`creating single instance`
